### PR TITLE
Spotify Auth draft + Spotify Auth Unit Tests

### DIFF
--- a/backend/spotifyAuth.js
+++ b/backend/spotifyAuth.js
@@ -1,0 +1,29 @@
+const axios = require('axios');
+const querystring = require('querystring');
+
+const client_id = process.env.SPOTIFY_CLIENT_ID;
+const client_secret = process.env.SPOTIFY_CLIENT_SECRET;
+const redirect_uri = process.env.SPOTIFY_REDIRECT_URI;
+
+async function getAccessToken(code) {
+    /*
+    const body = querystring.stringify({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri,
+    });
+
+    const headers = {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization:
+            'Basic ' + Buffer.from(`${client_id}:${client_secret}`).toString('base64'),
+    };
+
+    const response = await axios.post('https://accounts.spotify.com/api/token', body, { headers });
+
+    return response.data;
+
+     */
+}
+
+module.exports = { getAccessToken };

--- a/backend/spotifyAuth.test.js
+++ b/backend/spotifyAuth.test.js
@@ -1,0 +1,35 @@
+const axios = require('axios');
+const { getAccessToken } = require('./spotifyAuth');
+
+jest.mock('axios');
+
+describe('Spotify Auth', () => {
+    const mockCode = 'valid_code';
+
+    it('should get access token with valid code', async () => {
+        const mockResponse = {
+            data:{
+                access_token: 'access123',
+                token_type: 'Bearer',
+                expires_in: 3600,
+                refresh_token: 'refresh123',
+            },
+        };
+
+
+
+        axios.post = jest.fn().mockImplementation(() => Promise.resolve(mockResponse));
+
+        const result = await getAccessToken('valid code');
+
+        expect(axios.post).toHaveBeenCalled();
+
+        expect(result.access_token).toEqual('access123');
+    });
+
+    it('should throw error on invalid code', async () => {
+        axios.post = jest.fn().mockImplementation(() => Promise.reject(new Error('Failed')));
+
+        await expect(getAccessToken('invalid_code')).rejects.toThrow('Failed');
+    });
+});


### PR DESCRIPTION
First go at implementing Spotify Authorization and two unit tests for Auth. Unit tests test correctness of received data and if  there is returned an error if one occurs.